### PR TITLE
Update 'datecreated' to correct 'createdAt' syntax

### DIFF
--- a/docs/templating/record-and-records.md
+++ b/docs/templating/record-and-records.md
@@ -38,7 +38,7 @@ You can access regular fields in a record like these examples for either a
 {{ page.title }}
 {{ page.text }}
 
-Created on {{ entry.datecreated|date('Y-m-d')}}
+Created on {{ entry.createdAt|date('Y-m-d')}}
 
 The ContentType for this entry is {{ entry.contenttype.name }},
 and it contains {{ entry.contenttype.fields|length }} fields.


### PR DESCRIPTION
Update syntax in documentation for v4/5 as {{ record.datecreated|date("M d, ’y")}} may not work. Instead we should use: {{ record.createdAt|date("M d, ’y")}}. Other options are: publishedAt or modifiedAt